### PR TITLE
Enable bulk import by page

### DIFF
--- a/assets/js/zl-admin-custom.js
+++ b/assets/js/zl-admin-custom.js
@@ -1,24 +1,121 @@
-jQuery(document).ready(function() {
-    var post_type = jQuery("select[name='zl_post_type_get']").val();
+jQuery(document).ready(function($) {
+    var post_type = $("select[name='zl_post_type_get']").val();
+    var progressBar = $( "#progressbar" );
+    var bulkImportBtn = $('#bulk-import');
     GetCategoryziai(post_type);
 
-    jQuery("select[name='zl_post_type_get']").on("change", function(){
-        var post_type = jQuery(this).val();
+    $("select[name='zl_post_type_get']").on("change", function(){
+        var post_type = $(this).val();
         GetCategoryziai(post_type);
     });
 
+    $( progressBar ).progressbar({
+        value: 0
+    });
+
+    $(bulkImportBtn).click(function(){
+        fireBulkImporter();
+    });
+
+
     function GetCategoryziai(post_type) {
-        jQuery.ajax({
+        $.ajax({
             type: "POST",
             url: wpAjax.ajaxUrl,
             data: { action: "ziai_category_get", post_type: post_type },
             beforeSend: function () {
-                jQuery(".zl-ajax-loader").css({ display: "inline-block" });
+                $(".zl-ajax-loader").css({ display: "inline-block" });
             },
             success: function (result) {
-                jQuery(".post_type_category").html(result);
-                jQuery(".zl-ajax-loader").css({ display: "none" });
+                $(".post_type_category").html(result);
+                $(".zl-ajax-loader").css({ display: "none" });
             },
         });
+    }
+
+    function fireBulkImporter(){
+        $.ajax({
+            type: "POST",
+            url: wpAjax.ajaxUrl,
+            data: { action: "ziai_bulk_importer_init" },
+            beforeSend: function () {
+                $(bulkImportBtn).toggleClass('disabled');
+            },
+            success: function (result) {
+                // makes it <result.pages.total_pages irl
+                result = JSON.parse(result);
+                let currentPage = result.pages.page;
+                let maxPage = result.pages.total_pages; // set the maximum number of pages here
+
+                function nextPage() {
+                    if (currentPage <= maxPage) {
+                        bulkImporterNextPage(currentPage, currentPage + 1, function() {
+                            currentPage++;
+                            nextPage();
+                        });
+                    } else {
+                        console.log("All pages processed.");
+                    }
+                }
+
+                nextPage();
+            },
+        });
+    }
+
+    function bulkImporterNextPage(currentPage, nextPage, callback) {
+        $.ajax({
+            type: "POST",
+            url: wpAjax.ajaxUrl,
+            data: {
+                action: "ziai_bulk_importer_get_page",
+                currentPage: currentPage,
+                nextPage: nextPage
+            },
+            success: function (result) {
+                result = JSON.parse(result);
+                console.log(result);
+                if (callback) {
+                    callback();
+                }
+                console.log((result.pages.page/result.pages.total_pages)*100);
+                $( progressBar ).progressbar({
+                    value: (result.pages.page/result.pages.total_pages)*100
+                });
+                if(result.pages.page === 3){
+                    bulkImporterComplete();
+                }
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                console.log("Error:", textStatus, errorThrown);
+            }
+        });
+    }
+
+    /*function bulkImporterNextPage(currentPage, nextPage){
+        $.ajax({
+            type: "POST",
+            url: wpAjax.ajaxUrl,
+            data: {
+                action: "ziai_bulk_importer_get_page",
+                currentPage: currentPage,
+                nextPage: nextPage
+            },
+            beforeSend: function () {
+
+            },
+            success: function (result) {
+                $( progressBar ).progressbar({
+                    value: (result.pages.page/result.pages.totalPages)*100
+                });
+                if(result.pages.page === 3){
+                    bulkImporterComplete();
+                }
+            },
+        });
+    }*/
+
+    function bulkImporterComplete(){
+        $(bulkImportBtn).toggleClass('disabled');
     }
 });

--- a/assets/js/zl-admin-custom.js
+++ b/assets/js/zl-admin-custom.js
@@ -44,17 +44,17 @@ jQuery(document).ready(function($) {
             success: function (result) {
                 // makes it <result.pages.total_pages irl
                 result = JSON.parse(result);
-                let currentPage = result.pages.page;
+                let currentPage = result.pages.page+1;
                 let maxPage = result.pages.total_pages; // set the maximum number of pages here
-
+                $( progressBar ).progressbar({
+                    value: (result.pages.page/result.pages.total_pages)*100
+                });
                 function nextPage() {
                     if (currentPage <= maxPage) {
                         bulkImporterNextPage(currentPage, currentPage + 1, function() {
                             currentPage++;
                             nextPage();
                         });
-                    } else {
-                        console.log("All pages processed.");
                     }
                 }
 
@@ -74,15 +74,13 @@ jQuery(document).ready(function($) {
             },
             success: function (result) {
                 result = JSON.parse(result);
-                console.log(result);
                 if (callback) {
                     callback();
                 }
-                console.log((result.pages.page/result.pages.total_pages)*100);
                 $( progressBar ).progressbar({
                     value: (result.pages.page/result.pages.total_pages)*100
                 });
-                if(result.pages.page === 3){
+                if(result.pages.page === result.pages.total_pages){
                     bulkImporterComplete();
                 }
             },
@@ -92,30 +90,10 @@ jQuery(document).ready(function($) {
         });
     }
 
-    /*function bulkImporterNextPage(currentPage, nextPage){
-        $.ajax({
-            type: "POST",
-            url: wpAjax.ajaxUrl,
-            data: {
-                action: "ziai_bulk_importer_get_page",
-                currentPage: currentPage,
-                nextPage: nextPage
-            },
-            beforeSend: function () {
-
-            },
-            success: function (result) {
-                $( progressBar ).progressbar({
-                    value: (result.pages.page/result.pages.totalPages)*100
-                });
-                if(result.pages.page === 3){
-                    bulkImporterComplete();
-                }
-            },
-        });
-    }*/
-
     function bulkImporterComplete(){
         $(bulkImportBtn).toggleClass('disabled');
+        $( progressBar ).progressbar({
+            value: 0
+        });
     }
 });

--- a/automatic-articles-importer.php
+++ b/automatic-articles-importer.php
@@ -21,5 +21,6 @@ include_once('classes/class-admin-menu.php');
 include_once('classes/class-article-import.php');
 include_once('classes/class-ziai-cron.php');
 
-ZIAI_Modules::ziai_init();
+$ZIAI_Modules  = new ZIAI_Modules();
+$ZIAI_Modules->ziai_init();
 ZIAI_CronJob::ziai_cron_init();

--- a/includes/wp-ziai-article-form.php
+++ b/includes/wp-ziai-article-form.php
@@ -1,5 +1,14 @@
 <div class="wrap wp-ziai-article">
     <h1><?php esc_html_e('Automatic Articles Settings', 'ziai-articles'); ?></h1>
+    <?php
+    wp_enqueue_script('jquery-ui-progressbar');
+    $wp_scripts = wp_scripts();
+    wp_enqueue_style('plugin_name-admin-ui-css',
+        'http://ajax.googleapis.com/ajax/libs/jqueryui/' . $wp_scripts->registered['jquery-ui-core']->ver . '/themes/smoothness/jquery-ui.css',
+        false,
+        1.0,
+        false);
+    ?>
     <div id="wpbody" role="main">
         <div id="wpbody-content">
             <div class="wrap nosubsub">
@@ -71,6 +80,13 @@
                                         </div>
                                     </div>
                                 </form>
+                                <div>
+                                    <h5>Bulk Importer</h5>
+                                    <div id="progressbar"></div>
+                                    <div style="padding: 10px 0;">
+                                        <button class="button button-primary" id="bulk-import">Import All</button>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Allow importing more than 25 (or even 150) articles from Intercom

Adds a Bulk Import button that allows async chunk imports of 25 per page. Will iterate through all pages. 